### PR TITLE
Fix iPhone week view scroll lock — separate scroll axes

### DIFF
--- a/frontend/src/views/week-view.ts
+++ b/frontend/src/views/week-view.ts
@@ -239,15 +239,20 @@ export class CaleeWeekView extends LitElement {
     });
   }
 
+  /**
+   * On desktop, scroll the selected day column into view when the
+   * week changes. On narrow, horizontal scroll is disabled (3 columns
+   * fill the viewport), so this is a no-op.
+   */
   private _scrollSelectedDayIntoView(): void {
-    if (!this.narrow || this._hasAlignedSelectedDay) return;
+    if (this.narrow || this._hasAlignedSelectedDay) return;
     this._hasAlignedSelectedDay = true;
     requestAnimationFrame(() => {
       if (!this._panContainer) return;
       const selectedIndex = this._weekDays.findIndex((day) => sameDay(day, this.selectedDate));
       if (selectedIndex < 0) return;
-      const labelWidth = 40;
-      const dayWidth = 104;
+      const dayWidth = this._panContainer.scrollWidth / (this._weekDays.length + 1);
+      const labelWidth = dayWidth; // first column is the label
       const targetLeft = labelWidth + Math.max(0, selectedIndex - 1) * dayWidth;
       this._panContainer.scrollLeft = targetLeft;
     });
@@ -531,7 +536,7 @@ export class CaleeWeekView extends LitElement {
 
     :host([narrow]) .week-pan {
       overflow-x: hidden;
-      touch-action: none;
+      touch-action: pan-y;
     }
 
     .week-content {

--- a/frontend/src/views/week-view.ts
+++ b/frontend/src/views/week-view.ts
@@ -472,7 +472,7 @@ export class CaleeWeekView extends LitElement {
 
   render() {
     const labelW = this.narrow ? "40px" : "56px";
-    const dayW = this.narrow ? "104px" : "minmax(0, 1fr)";
+    const dayW = "minmax(0, 1fr)";
     const gridCols = `${labelW} repeat(${this._weekDays.length}, ${dayW})`;
     return html`
       <div class="week-view" style="--grid-cols: ${gridCols}; --day-count: ${this._weekDays.length}">
@@ -506,22 +506,40 @@ export class CaleeWeekView extends LitElement {
       display: flex;
       flex-direction: column;
       height: 100%;
+      min-height: 0;
       overflow: hidden;
     }
 
+    /*
+     * .week-pan handles horizontal overflow on desktop (7-day).
+     * On narrow/mobile, horizontal scroll is disabled because
+     * 3 columns fit the viewport — only vertical scroll is needed.
+     * Separating scroll axes between containers prevents the iOS
+     * WebKit gesture-ownership deadlock.
+     */
     .week-pan {
       flex: 1;
       min-height: 0;
+      display: flex;
+      flex-direction: column;
       overflow-x: auto;
       overflow-y: hidden;
       -webkit-overflow-scrolling: touch;
-      touch-action: pan-x pan-y;
+      touch-action: pan-x;
       overscroll-behavior-x: contain;
+    }
+
+    :host([narrow]) .week-pan {
+      overflow-x: hidden;
+      touch-action: none;
     }
 
     .week-content {
       min-width: 100%;
-      height: 100%;
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
     }
 
     /* ── Header ────────────────────────────────────────────────────── */
@@ -617,11 +635,12 @@ export class CaleeWeekView extends LitElement {
 
     .time-grid-scroll {
       flex: 1;
+      min-height: 0;
       overflow-y: auto;
-      overflow-x: visible;
-      min-width: 0;
+      overflow-x: hidden;
       -webkit-overflow-scrolling: touch;
-      touch-action: pan-x pan-y;
+      touch-action: pan-y;
+      overscroll-behavior-y: contain;
     }
 
     .time-grid {
@@ -768,10 +787,6 @@ export class CaleeWeekView extends LitElement {
       :host {
         --hour-height: 48px;
         --label-width: 40px;
-      }
-
-      .week-content {
-        min-width: calc(var(--label-width) + var(--day-count, 3) * 104px);
       }
 
       .day-header {


### PR DESCRIPTION
## Problem
Week view completely locked on iPhone — couldn't scroll vertically or horizontally. The previous CSS fixes (min-width, min-height) didn't address the root cause.

## Root Cause
Two nested scroll containers both declared `touch-action: pan-x pan-y`:
- `.week-pan` (outer) — intended for horizontal scroll
- `.time-grid-scroll` (inner) — intended for vertical scroll

iOS WebKit can't determine which container should own the touch gesture when both claim both axes. Result: neither scrolls.

## Fix
**Separate scroll axes between containers:**

| Container | Desktop | Narrow (mobile) |
|-----------|---------|-----------------|
| `.week-pan` | `overflow-x: auto`, `touch-action: pan-x` | `overflow-x: hidden`, `touch-action: none` |
| `.time-grid-scroll` | `overflow-y: auto`, `touch-action: pan-y` | Same |

**Additional changes:**
- Day columns use `minmax(0, 1fr)` on all sizes — narrow columns fill viewport width
- `.week-content` converted to flex column so time-grid fills remaining height
- `overscroll-behavior-y: contain` prevents iOS pull-to-refresh interference
- Removed mobile `min-width` calc (unnecessary without horizontal scroll)

## Why this works
On narrow (3-day), `.week-pan` does **nothing** (no overflow, no touch handling). Only `.time-grid-scroll` scrolls, and it only scrolls vertically. iOS has exactly one scrollable container with one axis — no ambiguity.

On desktop (7-day), `.week-pan` owns horizontal, `.time-grid-scroll` owns vertical. Each container claims one axis.

## Test plan
- [ ] iPhone: week view scrolls vertically through hours
- [ ] iPhone: 3 days visible, fill screen width
- [ ] iPad/desktop: 7-day week with horizontal scroll if needed
- [ ] No gesture lock on any device